### PR TITLE
Added optional parameter to allow setting of the tariff code.

### DIFF
--- a/OctopusAgile/Agile.py
+++ b/OctopusAgile/Agile.py
@@ -24,10 +24,11 @@ class Agile:
             minute = 30
         return t.replace(second=0, microsecond=0, minute=minute, hour=t.hour)
 
-    def __init__(self, area_code):
+    def __init__(self, area_code, tariff_code: str = "AGILE-18-02-21"):
         self.area_code = area_code
+        self.tariff_code = tariff_code
         self.base_url = (
-            "https://api.octopus.energy/v1/products/AGILE-18-02-21/electricity-tariffs"
+            f"https://api.octopus.energy/v1/products/{tariff_code}/electricity-tariffs"
         )
 
     def get_times_below(self, in_d: dict, limit: float):
@@ -176,7 +177,7 @@ class Agile:
         headers = {"content-type": "application/json"}
         r = requests.get(
             f"{self.base_url}/"
-            f"E-1R-AGILE-18-02-21-{self.area_code}/"
+            f"E-1R-{self.tariff_code}-{self.area_code}/"
             f"standard-unit-rates/{ date_from }{ date_to }",
             headers=headers,
         )


### PR DESCRIPTION
Over time, Octopus have introduced some new variants on the tariff for Agile, depending on when you signed up or your contract updated you may not be on the same one so I've added an optional parameter for the code to load the one you want the data for - can be set to any of these, will default to AGILE-18-02-21 (original behaviour).

AGILE-18-02-21 – The original version capped at 35p per unit
AGILE-22-07-22 – The cap rose to 55p
AGILE-22-08-31 – The cap was increased to 78p
AGILE-VAR-22-10-19 – This version raised the cap to £1 per unit and also introduced a new formula.
AGILE-FLEX-22-11-25 – Cap stays at £1 per unit but new formula only deducts 17.9p from higher unit prices.
